### PR TITLE
exclude test linting

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,4 +34,4 @@ jobs:
         run: cargo fmt --all -- --check
 
       - name: Run cargo clippy
-        run: cargo clippy --tests -- -D warnings
+        run: cargo clippy -- -D warnings

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+Cargo.lock


### PR DESCRIPTION
* main core files are included since they must be compiled to run the tests, but no need to lint tests